### PR TITLE
fix(wd-exec): match sentinel glued to unterminated stdout

### DIFF
--- a/apps/wiredesk-term/src/main.rs
+++ b/apps/wiredesk-term/src/main.rs
@@ -610,6 +610,7 @@ fn format_timeout_diagnostic(buf: &str, timeout_secs: u64) -> String {
 /// Pure helper, returns owned `String`.
 fn clean_stdout(buf: &str, uuid: &uuid::Uuid) -> String {
     let lines: Vec<&str> = buf.split('\n').collect();
+    let prefix = format!("__WD_DONE_{uuid}__");
 
     // Find sentinel line index (first match).
     let sentinel_idx = lines
@@ -634,24 +635,32 @@ fn clean_stdout(buf: &str, uuid: &uuid::Uuid) -> String {
     // shell echoes stdin. Filter both DONE and READY echoes.
     let done_echo = format!("__WD_DONE_{uuid}__$");
     let ready_echo = format!("__WD_READY_{uuid}__");
-    let kept: Vec<&str> = lines[lower..upper]
+    let echo_check = |s: &str| {
+        !(s.contains(&done_echo) || s.contains("echo ") && s.contains(&ready_echo))
+    };
+
+    let mut kept: Vec<String> = lines[lower..upper]
         .iter()
         .copied()
-        .filter(|l| {
-            // Drop the unexpanded echoed sentinel formatter.
-            if l.contains(&done_echo) {
-                return false;
-            }
-            // Drop the unexpanded echoed READY emitter (the line
-            // contains literal `echo __WD_READY_<uuid>__` — the
-            // *expanded* one already served as our lower bound and
-            // is not in this slice).
-            if l.contains("echo ") && l.contains(&ready_echo) {
-                return false;
-            }
-            true
-        })
+        .filter(|l| echo_check(l))
+        .map(|l| l.to_string())
         .collect();
+
+    // Sentinel-line may carry pre-prefix output when the command's
+    // stdout had no trailing newline (e.g. `head -c 800` on a JSON
+    // payload). The Bash sandwich glues the sentinel onto it. Recover
+    // that prefix portion as the last output line.
+    if let Some(idx) = sentinel_idx {
+        let line = lines[idx];
+        if let Some(pos) = line.rfind(&prefix) {
+            if pos > 0 {
+                let pre = line[..pos].trim_end_matches('\r');
+                if !pre.is_empty() && echo_check(pre) {
+                    kept.push(pre.to_string());
+                }
+            }
+        }
+    }
 
     let mut out = kept.join("\n");
     while out.ends_with('\n') || out.ends_with('\r') {
@@ -660,19 +669,35 @@ fn clean_stdout(buf: &str, uuid: &uuid::Uuid) -> String {
     out
 }
 
-/// Parse a single line for our sentinel marker. Returns `Some(exit_code)`
-/// only when the line is **exactly** `__WD_DONE_<our-uuid>__<digits>`,
-/// modulo trailing whitespace. Crucially the digit-class match is what
-/// disambiguates the *expanded* sentinel (e.g. `__WD_DONE_xxx__0`) from
-/// the *stdin echo* of the format-string (e.g. `…__WD_DONE_xxx__$LASTEXITCODE`)
-/// — the literal `$LASTEXITCODE` / `$?` won't parse as `i32`.
+/// Parse a line for our sentinel marker. Returns `Some(exit_code)` when
+/// `__WD_DONE_<our-uuid>__<digits>` appears anywhere in the line.
 ///
-/// UUID is included in the match so a third party emitting a sentinel
-/// with a *different* UUID can't fool us.
+/// We anchor with `rfind` (not `strip_prefix`) because Bash sandwich
+/// `<cmd>; echo "__WD_DONE_<uuid>__$?"` glues the sentinel directly
+/// onto unterminated `<cmd>` output (e.g. `head -c 800` on a JSON
+/// payload without trailing newline). Wire stream then arrives as
+/// `<800-byte JSON>__WD_DONE_<uuid>__0\n` — one line, sentinel mid-string.
+/// `strip_prefix` would miss it; `rfind` finds the last (so always the
+/// expanded one — earlier echoes carry literal `$LASTEXITCODE`/`$?`
+/// which the digit parse rejects).
+///
+/// The digit-class match disambiguates the *expanded* sentinel from
+/// the *stdin echo* of the format-string (literal `$LASTEXITCODE` /
+/// `$?` won't parse as `i32`). UUID is included in the match so a
+/// third party emitting a sentinel with a *different* UUID can't fool us.
 fn parse_sentinel(line: &str, uuid: &uuid::Uuid) -> Option<i32> {
     let prefix = format!("__WD_DONE_{uuid}__");
-    let rest = line.trim().strip_prefix(&prefix)?;
-    rest.parse::<i32>().ok()
+    let trimmed = line.trim();
+    let pos = trimmed.rfind(&prefix)?;
+    let rest = &trimmed[pos + prefix.len()..];
+    // Take only the leading digit run (with optional minus). Anything
+    // after — trailing garbage, ANSI escapes, prompt fragments — is
+    // ignored. parse on empty string fails, which correctly rejects
+    // `…__$LASTEXITCODE` and `…__$?` echoes.
+    let end = rest
+        .find(|c: char| !c.is_ascii_digit() && c != '-')
+        .unwrap_or(rest.len());
+    rest[..end].parse::<i32>().ok()
 }
 
 /// `true` when `line` looks like a Windows PowerShell prompt:
@@ -1589,6 +1614,56 @@ mod tests {
         host_thread.join().expect("host thread");
     }
 
+    /// AC4 of `docs/briefs/sentinel-detection-ansi-tail.md`: command
+    /// emits stdout WITHOUT trailing newline, sentinel arrives glued to
+    /// it in the same wire chunk, plus Starship-style ANSI tail in the
+    /// following chunk. Pre-fix run_oneshot timed out on this; now must
+    /// match sentinel and clean stdout to just the JSON.
+    #[test]
+    fn run_oneshot_handles_unterminated_output_with_ansi_tail() {
+        let (writer, reader, host) = make_split_pair();
+        let host_thread = thread::spawn(move || {
+            // Step 1: ssh hop sent first.
+            let ssh_cmd = host
+                .recv_shell_input(Duration::from_secs(2))
+                .expect("client should send ssh -tt");
+            assert!(ssh_cmd.starts_with("ssh -tt prod"), "got: {ssh_cmd:?}");
+
+            // Step 2: emit a remote prompt so client sends the bash payload.
+            host.emit_chunk("Welcome\r\nuser@host:~$ ");
+
+            // Step 3: client sends the bash payload (echo READY; cmd; echo DONE).
+            let cmd = host
+                .recv_shell_input(Duration::from_secs(2))
+                .expect("client should send bash payload");
+            let uuid = extract_uuid_from_payload(&cmd);
+
+            // Step 4: simulate the bug scenario — bash echoes the
+            // payload, emits READY, runs cmd whose stdout has no
+            // trailing newline, then expanded sentinel glued onto it.
+            // Starship-style ANSI prompt arrives in a separate chunk.
+            host.emit_chunk(&format!(
+                "echo __WD_READY_{uuid}__; head -c 800 ...; echo \"__WD_DONE_{uuid}__$?\"\r\n"
+            ));
+            host.emit_chunk(&format!("__WD_READY_{uuid}__\r\n"));
+            // The unterminated output + sentinel in one chunk:
+            host.emit_chunk(&format!(
+                "{{\"hits\":{{\"total\":42}},\"aggs\":\"x\"}}__WD_DONE_{uuid}__0\r\n"
+            ));
+            // ANSI Starship tail in following chunk — must NOT confuse
+            // the parser, sentinel was already detected above.
+            host.emit_chunk(
+                "\x1b[1m\x1b[7m%\x1b[27m\x1b[1m\x1b[0m \r\n\x1b[1;33muser\x1b[0m \r\n\
+                 ➜ \x1b[K\x1b[?2004h",
+            );
+        });
+
+        let code = run_oneshot(writer, reader, "head -c 800 ...", Some("prod"), 5)
+            .expect("run_oneshot ok");
+        assert_eq!(code, 0, "should complete with exit 0, not timeout");
+        host_thread.join().expect("host thread");
+    }
+
     /// Extract the UUID embedded in the `format_command` payload so
     /// the host-side test thread can build the matching expanded
     /// sentinel.
@@ -1719,6 +1794,65 @@ mod tests {
         assert_eq!(parse_sentinel(&format!("__WD_DONE_{uuid}__"), &uuid), None);
         // Non-numeric tail.
         assert_eq!(parse_sentinel(&format!("__WD_DONE_{uuid}__abc"), &uuid), None);
+    }
+
+    /// Regression for the unterminated-output bug: command that emits
+    /// stdout WITHOUT trailing newline (e.g. `head -c 800` on a JSON
+    /// payload) glues the bash sandwich's expanded sentinel directly
+    /// after it. parse_sentinel must still match.
+    #[test]
+    fn parse_sentinel_after_unterminated_output() {
+        let uuid = uuid::Uuid::nil();
+        let glued = format!("<long unterminated json>__WD_DONE_{uuid}__0");
+        assert_eq!(parse_sentinel(&glued, &uuid), Some(0));
+
+        let glued_nonzero = format!("xxxxx__WD_DONE_{uuid}__7");
+        assert_eq!(parse_sentinel(&glued_nonzero, &uuid), Some(7));
+    }
+
+    /// Trailing garbage after the digit run (ANSI escapes, prompt
+    /// fragments) must not break the parse — only the leading digits
+    /// are consumed.
+    #[test]
+    fn parse_sentinel_with_trailing_garbage() {
+        let uuid = uuid::Uuid::nil();
+        let with_ansi = format!("__WD_DONE_{uuid}__42\x1b[K\x1b[?2004h");
+        assert_eq!(parse_sentinel(&with_ansi, &uuid), Some(42));
+    }
+
+    /// A line that contains both an *echoed* sentinel formatter (carrying
+    /// literal `$?` or `$LASTEXITCODE`) AND an *expanded* one — pick the
+    /// expanded by `rfind` (last occurrence), since echo always precedes
+    /// expansion in the wire stream.
+    #[test]
+    fn parse_sentinel_prefers_expanded_over_echo_in_same_line() {
+        let uuid = uuid::Uuid::nil();
+        let mixed = format!(
+            "echo \"__WD_DONE_{uuid}__$?\" some-output __WD_DONE_{uuid}__7"
+        );
+        assert_eq!(parse_sentinel(&mixed, &uuid), Some(7));
+    }
+
+    /// `clean_stdout` must recover the pre-sentinel output when the
+    /// command's stdout had no trailing newline (the unterminated-output
+    /// scenario from `parse_sentinel_after_unterminated_output`). The
+    /// sentinel itself must NOT leak into user-visible stdout.
+    #[test]
+    fn clean_stdout_recovers_prefix_from_mixed_sentinel_line() {
+        let uuid = uuid::Uuid::nil();
+        let buf = format!(
+            "__WD_READY_{uuid}__\n\
+             {{\"hits\":{{\"total\":42}}}}__WD_DONE_{uuid}__0\n"
+        );
+        let out = clean_stdout(&buf, &uuid);
+        assert!(
+            out.contains("{\"hits\":{\"total\":42}}"),
+            "expected JSON output preserved: {out:?}"
+        );
+        assert!(
+            !out.contains("__WD_DONE_"),
+            "sentinel must not leak into stdout: {out:?}"
+        );
     }
 
     #[test]

--- a/docs/briefs/sentinel-detection-ansi-tail.md
+++ b/docs/briefs/sentinel-detection-ansi-tail.md
@@ -1,0 +1,96 @@
+# Бриф: `wd --exec` миссит sentinel когда тот приходит в одном chunk'е со Starship-prompt'ом / ANSI
+
+**Цель:** починить sentinel-detection в `run_oneshot` так, чтобы строка `__WD_DONE_<uuid>__N` корректно матчилась даже когда вместе с ней в один `ShellOutput`-chunk прилетают байты Starship-prompt'а / ANSI escape codes (типичный случай для `--ssh ALIAS` через `ssh -tt`).
+
+**Найден:** 04.05.26, при первом же тесте `wd --exec` после merge `feat/wd-exec-fixes` (master `7f8dd92`). Раньше не проявлялся потому что P2 (`format_timeout_diagnostic`) не существовал — без `last bytes received` в stderr баг выглядел как «команда висит до timeout», и казалось что виноват ES / медленный канал. P2 диагностика немедленно показала что sentinel уже в буфере.
+
+## Симптом
+
+`wd --exec --ssh prod-mup "<reasonable read-only command>"` отрабатывает на remote за ~4 сек, sentinel генерируется и попадает в client buffer, но `wd --exec` **не распознаёт его** и продолжает ждать до `--timeout` истечения. Exit code — 124 (timeout convention) хотя реальный exit команды был 0.
+
+## Воспроизведение
+
+Команда (один из подтверждённых случаев — ES `_search` с тремя aggregations, payload ~619 байт, помещается в новый `MAX_PAYLOAD = 4096`):
+
+```bash
+wd --exec --timeout 90 --ssh prod-mup "curl -s -XPOST 'http://10.24.200.219:9200/mup-srv-production-*/_search?size=0' -H 'Content-Type: application/json' -d '{\"query\":{\"bool\":{\"filter\":[{\"range\":{\"@timestamp\":{\"gte\":\"now-1h\"}}},{\"terms\":{\"level.keyword\":[\"Error\",\"Fatal\"]}}]}},\"aggs\":{\"by_min\":{\"date_histogram\":{\"field\":\"@timestamp\",\"fixed_interval\":\"5m\"}},\"by_class\":{\"terms\":{\"field\":\"exceptions.ClassName.keyword\",\"size\":5}},\"by_path\":{\"terms\":{\"field\":\"fields.RequestPath.keyword\",\"size\":5}}}}' | head -c 800"
+```
+
+Ожидаемое: stdout с ES JSON (≤ 800 байт после `head -c`), exit 0, latency ~5 сек.
+
+Фактическое:
+- stdout пуст
+- stderr: `wiredesk-term: --exec timeout after 90s (no sentinel from host)\nlast bytes received: "..."` (см. ниже)
+- exit 124
+- latency 90 сек (упёрлись в `--timeout`)
+
+`last bytes received` (P2 diagnostic) — обрезок в 256 байт, дословно:
+
+```
+"2c-4e46-bf2c-62566843b74d__0\r\n\u{1b}[1m\u{1b}[7m%\u{1b}[27m\u{1b}[1m\u{1b}[0m                                                                               \r \r\r\u{1b}[0m\u{1b}[27m\u{1b}[24m\u{1b}[J\u{1b}[1;33muser\u{1b}[0m in \u{1b}[1;2;32m🌐 cgu-knd-firecards-1\u{1b}[0m in \u{1b}[1;36m~\u{1b}[0m ⏱ 4s \r\n➜ \u{1b}[K\u{1b}[?1h\u{1b}=\u{1b}[?2004h"
+```
+
+Видно:
+1. **Хвост `__WD_DONE_<uuid>__0\r\n`** — sentinel целиком в буфере (UUID обрезан 256-байт окном до окончания `2c-4e46-bf2c-62566843b74d`, но конец `__0\r\n` интактен).
+2. **Сразу за `\r\n` начинаются ANSI escape codes** Starship-prompt'а (`\u{1b}[1m\u{1b}[7m%`...).
+3. `⏱ 4s` в prompt'е → команда сама отработала за **4 секунды**, не за 90.
+
+Sentinel прибыл в буфер, но `parse_sentinel` (или вышестоящая логика чтения buffer'а) пропустил его.
+
+## Что наблюдалось
+
+- Воспроизводимо. Один и тот же запрос — один и тот же эффект.
+- Меньшие команды (типа `echo alive`, `hostname`, `docker ps`) — работают штатно. Это значит критерий не «всегда промахивается», а зависит от того, **что приходит после sentinel'а до следующего read-tick'а** read-loop'а. Для болтливого Starship-prompt'а с тяжёлой ANSI-шапкой шанс попасть в этот случай высокий.
+- Без P2 (старые билды) проблема **выглядела бы как ES timeout** или «канал глюканул» — и тратилось бы время на неверный диагноз. P2 — необходимая опора для воспроизведения.
+
+## Гипотеза
+
+Парсер sentinel'а (анкеренный regex по строке, типа `^__WD_DONE_<uuid>__(\d+)\s*$`) применяется к буферу line-by-line. Один из двух сценариев:
+
+**(а) Strip-ANSI работает на уровне output'а в stdout, а sentinel-detection — на сыром буфере.** Если в строке с sentinel'ом перед `__WD_DONE_` есть ANSI escape (например, prompt `\r` без `\n` оставляет курсор в той же строке, и Starship potом выкидывает свои byte'ы прямо перед sentinel'ом) — `^` regex не находит начало.
+
+**(б) Sentinel и Starship-prompt пришли вместе в одном chunk'е, разделение по строкам пошло по `\n` буфера, но один из split'ов слипся.** Например, если split на `\n` (без обработки `\r\n` как пары), хвост строки sentinel'а `__0\r` остаётся склеенным с началом следующей line — и regex `\d+\s*$` тогда `\s*` поглощает `\r`, но дальше идёт ещё ANSI и regex `$` не сработает.
+
+Скорее всего **(б)** — split по `\n` с попаданием `\r` в trailing-часть, плюс жадный `\s*` или strict `$`. Точная диагностика — через `RUST_LOG=debug` запустить тот же тест и посмотреть какие именно строки попадают в `parse_sentinel`.
+
+## Acceptance criteria
+
+- **AC1.** Тот же запрос (см. «Воспроизведение») — `wd --exec` завершается за ≤ 10 сек, exit 0, stdout содержит начало ES-ответа.
+- **AC2.** Регрессия — все 354 существующих теста проходят (`cargo test --workspace -- --test-threads=1`).
+- **AC3.** Новый unit-test `parse_sentinel_after_starship_prompt_chunk` (table-driven):
+  - input: `"output\n__WD_DONE_<uuid>__0\r\n\x1b[1m\x1b[7m%...➜ "` (sentinel + ANSI Starship tail в одном chunk'е)
+  - expected: detected exit code = 0
+  - Вариации: exit codes 1, 7, 130; CRLF / LF normalization; sentinel в самом конце буфера vs sentinel + ещё output после.
+- **AC4.** Новый integration-test с `MockTransport::pair`: host имитирует ssh-сценарий, шлёт `ShellOutput` с payload'ом, в котором `__WD_DONE_<uuid>__0\r\n` в одном chunk'е с Starship ANSI tail. Wd-term корректно завершается, не упирается в timeout.
+- **AC5.** `clean_stdout` после fix'а корректно отрезает sentinel-line из output'а — никаких `__WD_DONE_<uuid>__N` в stdout пользователя.
+
+## Тестирование
+
+**Unit (table-driven)** в `apps/wiredesk-term/src/main.rs::tests`:
+- `parse_sentinel_with_ansi_after`: `"__WD_DONE_<uuid>__7\r\n\x1b[1mfoo"` → `Some(7)`.
+- `parse_sentinel_with_starship_glob`: реальный capture из bug report'а (выше) → `Some(0)`.
+- `parse_sentinel_at_buffer_end_with_crlf`: `"prefix\n__WD_DONE_<uuid>__0\r\n"` → `Some(0)`.
+- `parse_sentinel_no_match_when_uuid_wrong`: с другим UUID → `None`. (regression)
+- `parse_sentinel_no_match_on_echoed_literal_command`: входная команда `echo "__WD_DONE_<uuid>__$?"` echo'ится bash'ем как литерал — `__WD_DONE_<uuid>__$?` без `\d+` — `None` через `\d+` regex (regression, уже есть).
+
+**Integration** в `apps/wiredesk-term/tests/`:
+- `oneshot_completes_when_sentinel_chunked_with_prompt`: `MockTransport::pair`, host шлёт `ShellOpen`-handshake, потом несколько `ShellOutput`'ов с output, последний chunk = `<command output>\n__WD_DONE_<uuid>__0\r\n<ANSI Starship junk>\r\n➜ `. Wd-term завершается за < 1 сек, exit 0, clean stdout.
+
+**Live re-test** на CH340 + prod-mup:
+- Тот же запрос из «Воспроизведение». Ожидаемое: завершение за ~5 сек, exit 0.
+
+## Не в scope
+
+- Полная нормализация всех ANSI sequences в буфере перед detection (если решение — strip ANSI на line-by-line при detect'е, ОК; полный CSI-state-machine — overkill).
+- Изменение wire-формата sentinel'а (UUID + exit code остаются как есть).
+- ConPTY-mode для `wd --exec` — exec осознанно остаётся pipe-mode (см. `docs/wd-exec-usage.md`), здесь не трогаем.
+
+## Сложность
+
+**Low.** Точечная правка в parser'е sentinel'а + 4-5 unit-тестов + 1 integration. Скорее всего ≤ 50 строк нового кода + ~80 строк тестов. Bug чисто алгоритмический — нет архитектурных изменений.
+
+## Связанные
+
+- master `7f8dd92` (squash `feat/wd-exec-fixes` в master, 04.05.26) — добавил P2 `format_timeout_diagnostic`, которое сделало воспроизведение этого bug'а очевидным.
+- master `aaee62c` — ConPTY для interactive `wd`. Не относится к exec-pipe path, но напоминание что в exec mode TTY симулируется через `ssh -tt` на remote, отсюда ANSI escape codes от Starship.
+- memory у клиента: `feedback_wd_exec_practical_limits.md` — описывает workaround на стороне agent'а до фикса (смотреть `last bytes received`, не повторять команду).


### PR DESCRIPTION
## Summary

Bug found in the wild after PR #11 merge — `wd --exec` via `--ssh` timed out even though the P2 diagnostic dump showed the sentinel sat right in the buffer. Brief: `docs/briefs/sentinel-detection-ansi-tail.md` (commit \`e48cc2a\`).

**Root cause:** Bash sandwich `<cmd>; echo \"__WD_DONE_<uuid>__\$?\"` glues the expanded sentinel directly onto cmd's stdout when stdout has no trailing newline (e.g. \`head -c 800\` on a JSON payload). Wire stream then arrives as \`<800-byte JSON>__WD_DONE_<uuid>__0\\n\` — one line, sentinel mid-string. \`parse_sentinel\` was using \`strip_prefix\` (anchor-at-start) and missed it.

The bug existed since PR #9 but was masked by lack of diagnostic. PR #11's \`format_timeout_diagnostic\` is what made this discoverable — the live \`last bytes received: \"...\"\` in the brief shows sentinel + Starship ANSI tail clearly.

**Fix:**

1. \`parse_sentinel\`: \`rfind\` instead of \`strip_prefix\`. Last occurrence wins so an *echoed* sentinel with literal \`\$LASTEXITCODE\`/\`\$?\` in the same line never beats the expanded one. After the prefix, take only the leading digit run — trailing garbage (ANSI escapes, prompt fragments) is ignored.
2. \`clean_stdout\`: if the sentinel-line carries pre-prefix output (mixed line), recover that prefix as a kept output line. Without this, AC5 would leak — exit code would be right but user-visible stdout loses the JSON.

Both changes are small and local — no architectural shifts.

## Test plan

Unit (5 new):

- [x] \`parse_sentinel_after_unterminated_output\` — the headline bug (\"\<long unterminated json>__WD_DONE_<uuid>__0\" → Some(0))
- [x] \`parse_sentinel_with_trailing_garbage\` — ANSI tail after the digit run
- [x] \`parse_sentinel_prefers_expanded_over_echo_in_same_line\` — rfind picks the expanded sentinel when an echoed \`\$?\` formatter sits earlier in the same line
- [x] \`clean_stdout_recovers_prefix_from_mixed_sentinel_line\` — AC5: pre-sentinel output preserved, sentinel itself doesn't leak
- [x] \`run_oneshot_handles_unterminated_output_with_ansi_tail\` — AC4 integration via MockTransport pair, exact bug-report scenario

Existing (regression):

- [x] \`cargo test --workspace -- --test-threads=1\` — 359 passing (354 + 5 new), no regressions
- [x] \`cargo clippy --workspace -- -D warnings\` clean

Live (after merge — needs Win11 host + redeploy of new \`wd\` binary on Mac side; host unchanged):

- [ ] AC1: the exact ES query from the brief — \`wd --exec --timeout 90 --ssh prod-mup \"...head -c 800\"\` completes in ~5 sec, exit 0, stdout contains start of ES response

🤖 Generated with [Claude Code](https://claude.com/claude-code)