### PR TITLE
chore(wd-exec): probe-tests + base64 workaround for quoting collapse

### DIFF
--- a/crates/wiredesk-exec-core/src/helpers.rs
+++ b/crates/wiredesk-exec-core/src/helpers.rs
@@ -488,6 +488,63 @@ mod tests {
     }
 
     #[test]
+    fn format_command_preserves_inline_json_quotes_powershell() {
+        // Probe (2026-05-05, brief wd-exec-payload-quoting):
+        // Real prod-symptom — ES `_search` with nested bool/filter
+        // returns HTTP 400 because the outer `"` around field names get
+        // collapsed somewhere in the macOS-bash → wd → PS → curl chain.
+        //
+        // This test pins down whether `format_command` itself eats
+        // quotes. If it PASSES, the bug is NOT in our wrapper —
+        // it's downstream (PS native command parsing, ssh -tt PTY echo
+        // collapse, cp866 codepage read of stdin, curl arg parsing).
+        // If it FAILS, we've localized the bug to format_command and
+        // the fix is one-line escape adjustment here.
+        let uuid = uuid::Uuid::nil();
+        let cmd = r#"curl.exe -d '{"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":"now-1h"}}}]}}}'"#;
+        let out = format_command(&uuid, ShellKind::PowerShell, cmd);
+
+        let cmd_quote_count = cmd.matches('"').count();
+        let out_quote_count = out.matches('"').count();
+        // format_command adds exactly 2 quotes for the sentinel emit
+        // (`"__WD_DONE_<uuid>__$LASTEXITCODE"`); everything else must
+        // be a verbatim copy of the user cmd.
+        assert_eq!(
+            out_quote_count - cmd_quote_count,
+            2,
+            "format_command must preserve every `\"` from the user cmd verbatim, \
+             only adding 2 for the sentinel emit. cmd={cmd:?} out={out:?}"
+        );
+        assert!(
+            out.contains(cmd),
+            "user cmd must appear verbatim inside try {{ ... }}: out={out:?}"
+        );
+    }
+
+    #[test]
+    fn format_command_preserves_inline_json_quotes_bash() {
+        // Same probe for the `--ssh ALIAS` path. Bash-on-remote is
+        // the actual interpreter once the `ssh -tt` hop is in place.
+        let uuid = uuid::Uuid::nil();
+        let cmd = r#"curl -d '{"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":"now-1h"}}}]}}}'"#;
+        let out = format_command(&uuid, ShellKind::Bash, cmd);
+
+        let cmd_quote_count = cmd.matches('"').count();
+        let out_quote_count = out.matches('"').count();
+        // bash format adds 2 for the `"__WD_DONE_<uuid>__$?"` emit.
+        assert_eq!(
+            out_quote_count - cmd_quote_count,
+            2,
+            "format_command must preserve every `\"` from the user cmd verbatim. \
+             cmd={cmd:?} out={out:?}"
+        );
+        assert!(
+            out.contains(cmd),
+            "user cmd must appear verbatim between READY and DONE. out={out:?}"
+        );
+    }
+
+    #[test]
     fn format_command_uuid_in_payload() {
         let uuid_a = uuid::Uuid::nil();
         let uuid_b = uuid::Uuid::from_u128(0x1234_5678_90ab_cdef_1234_5678_90ab_cdef);

--- a/docs/wd-exec-usage.md
+++ b/docs/wd-exec-usage.md
@@ -122,6 +122,44 @@ Decode error → exit 125 (transport-class) с диагностикой в stder
 ### Sequential calls
 - Два `wd --exec` подряд работают (host slot free'ится между ними через ShellClose+Disconnect). Но **между ними ~2 сек handshake'а каждый раз**. Для серии команд лучше — одна команда с `;` или `&&`.
 
+### Inline JSON / nested-quoted payloads — base64-passthrough
+
+**Симптом:** сложный inline JSON в `curl -d '{...}'` через `wd --exec` приходит к target-команде с потерянными `"` вокруг field names — ES возвращает HTTP 400 `was expecting double-quote to start field name at column 3`. Простые JSON (`{"query":{"match_all":{}}}`) проходят, nested bool/filter/range — нет. Точное место quote-collapse'а не локализовано (probe-тесты в `crates/wiredesk-exec-core/src/helpers.rs` подтверждают что **обёртка `format_command` кавычки сохраняет** — collapse происходит ниже, в PS native command argument parsing для `{...}` literals или в `ssh -tt` PTY echo + bash re-tokenization).
+
+**Workaround — base64 payload, decode на host'е, передача через temp-файл:**
+
+`--ssh ALIAS` path (bash на remote):
+
+```bash
+# Mac side — encode payload в base64 (charset alphanumeric + +/= — никаких quoting concerns):
+QUERY_B64=$(printf '%s' '{"query":{"bool":{"filter":[{"range":{"@timestamp":{"gte":"now-1h"}}}]}}}' | base64)
+
+# Single wd --exec call: decode на remote → temp-file → curl --data-binary → cleanup:
+wd --exec --ssh prod-mup "echo '$QUERY_B64' | base64 -d > /tmp/wd-q.json && \
+  curl -s -XPOST 'http://10.24.200.219:9200/_search' \
+    -H 'Content-Type: application/json' \
+    --data-binary @/tmp/wd-q.json && \
+  rm /tmp/wd-q.json"
+```
+
+PS-direct path (host PowerShell):
+
+```bash
+QUERY_B64=$(printf '%s' '{"query":{"bool":...}}' | base64)
+
+wd --exec "[System.IO.File]::WriteAllBytes('C:\\Temp\\wd-q.json', [Convert]::FromBase64String('$QUERY_B64')); \
+  curl.exe -s -XPOST 'http://es:9200/_search' \
+    -H 'Content-Type: application/json' \
+    --data-binary '@C:\\Temp\\wd-q.json'; \
+  Remove-Item C:\\Temp\\wd-q.json"
+```
+
+**Почему работает:** base64 charset (alphanumeric + `+/=`) не содержит `"`/`'`/`{`/`}` — все четыре «опасных» символа quoting-cascade'а отсутствуют. Payload проходит через все слои (bash → wd serial → PS / ssh-tt → curl) литерально, decode восстанавливает исходные байты на remote.
+
+**Когда применять:** сложный JSON (3+ уровня вложенности bool/filter), длинные `_source` arrays, любой payload с nested `\"` где простое одинарное quoting не выживает. Для простых запросов (`docker ps`, `curl ... '/health'`) обычное inline-quoting работает — base64 overhead не нужен.
+
+**Future:** если эпизодов quote-collapse наберётся больше — `wd --exec --stdin` (передача payload'а на stdin command'а) станет первоклассным решением. Бриф `docs/briefs/wd-exec-payload-quoting.md` зафиксирован, но реализация отложена пока workaround покрывает known кейсы.
+
 ## Чего НЕЛЬЗЯ делать
 
 - **Interactive prompts** (`sudo` без `-S`, `git push` с пасс-фразой ключа, `ssh` с password auth, `vim`, `htop`, `git interactive rebase`) — сломаются. `wd --exec` намеренно pipe-mode (нужно для sentinel detection в clean stdout); для интерактивщины используй просто `wd` без `--exec` — там ConPTY и всё работает. Для скриптов внутри `--exec` используй non-interactive формы:


### PR DESCRIPTION
## Summary

Investigation deliverable for brief \`docs/briefs/wd-exec-payload-quoting.md\`. **Не фиксит** quoting bug — фиксирует invariant'ы и documented workaround. Полноценный \`--stdin\` flag отложен до накопления больше эпизодов.

## Что добавлено

**\`crates/wiredesk-exec-core/src/helpers.rs::tests\`** — два probe-теста:
- \`format_command_preserves_inline_json_quotes_powershell\`
- \`format_command_preserves_inline_json_quotes_bash\`

Оба passed. Это **negative result**: \`format_command\` — pure literal substitution, **не** ест \`"\` из user'ской cmd. Bug происходит downstream:
- PowerShell native command argument parsing для \`{...}\` literals (PS-direct path)
- ssh -tt PTY echo + bash re-tokenization (--ssh path)

Locate точное место можно только живым Win11 repro session'ом — следующий шаг если эпизодов накопится.

**\`docs/wd-exec-usage.md\`** — раздел «Inline JSON / nested-quoted payloads — base64-passthrough». Pattern: Mac-side \`base64\`-encode → remote \`base64 -d > tempfile\` → \`curl --data-binary @file\`. base64 charset (alphanumeric + +/=) не содержит \`"/'/{/}\` — quoting cascade collapses to identity на всех слоях.

Документированы оба пути (\`--ssh\` через bash на remote и PS-direct через \`[Convert]::FromBase64String\`).

## Что НЕ изменилось

- Runtime код **не трогался**. Только \`#[cfg(test)] mod tests\` блок + docs.
- Wire протокол идентичен master'у.
- **Win11 host пересобирать не нужно.**
- \`WireDesk.app\` пересобирать не нужно.

## Tests

- \`cargo test -p wiredesk-exec-core\` — 84 passed (было 82, +2 probe), 0 failed.
- \`cargo clippy -p wiredesk-exec-core -- -D warnings\` — clean.

## Review

Прошёл 3× прогона \`/pg.review\` (Claude + Codex). Codex поймал три тонкости:
- неверное FD-lifetime объяснение в Q3 host-quirks (исправлено)
- неработающий redirect-fallback (удалён)
- ложное утверждение про \`[Console]::InputEncoding\` в Q2 (заменено на честный caveat)

Все findings закрыты.

## Followup

Параллельно с этим PR'ом расследовалась проблема **зависания host-канала** после broken-quoting timeout — host-log показал что Mac GUI перестаёт слать heartbeat'ы во время \`run_oneshot\` блокирующего цикла, host через 6s кооперативно дисконнектит, reconnect занимает 1m+. План в \`docs/plans/concurrent-finding-lighthouse.md\` (untracked в этом PR'е, поедет отдельной веткой).

🤖 Generated with [Claude Code](https://claude.com/claude-code)