### PR TITLE
fix(host): extend heartbeat budget while shell is open

### DIFF
--- a/apps/wiredesk-host/src/session.rs
+++ b/apps/wiredesk-host/src/session.rs
@@ -23,6 +23,17 @@ const HEARTBEAT_TIMEOUT_IDLE: Duration = Duration::from_secs(6);
 /// real disconnect.
 const HEARTBEAT_TIMEOUT_BUSY: Duration = Duration::from_secs(30);
 
+/// Pure helper — pick busy or idle heartbeat budget. Extracted so the
+/// branching can be unit-tested without spawning a real `ShellProcess`
+/// (which forks PowerShell on Windows and isn't reachable from CI).
+fn heartbeat_timeout_for(clipboard_busy: bool, shell_open: bool) -> Duration {
+    if clipboard_busy || shell_open {
+        HEARTBEAT_TIMEOUT_BUSY
+    } else {
+        HEARTBEAT_TIMEOUT_IDLE
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum SessionState {
@@ -128,15 +139,32 @@ impl<T: Transport, I: InputInjector> Session<T, I> {
             Instant::now() - HEARTBEAT_TIMEOUT_BUSY - Duration::from_secs(1);
     }
 
-    /// Effective heartbeat timeout — extended while a clipboard transfer
-    /// is in flight to avoid false-positive disconnects when the wire is
-    /// saturated by chunk traffic.
+    /// Effective heartbeat timeout — extended while wire is saturated, so
+    /// false-positive disconnects don't kill the channel mid-transfer.
+    /// Two saturation sources today:
+    ///
+    /// 1. **Clipboard** — chunked image / large text transfer in flight.
+    /// 2. **Shell** — `wd --exec` (especially `--ssh ALIAS curl ...`)
+    ///    streaming command output back. With CH340 @ 115200 baud the wire
+    ///    runs at ~11 KB/s; a 24 KB ES `_search` response monopolises it
+    ///    for ~2 seconds plus any server-side delay, and the client's
+    ///    writer thread (which also services heartbeats) can fall further
+    ///    behind if it's writing back too. With the prior 6s idle timeout
+    ///    the channel reliably tore down on every non-trivial ES read.
+    ///    Live-test 2026-05-06: 43s between `opening shell` and
+    ///    `heartbeat timeout — disconnecting` for an ES `_search?size=1`
+    ///    query (~24 KB JSON response). With the busy budget (30s) plus
+    ///    the natural prefix of MOTD / ssh hop the channel survives.
+    ///
+    /// `self.shell.is_some()` is the simplest signal — true between
+    /// `ShellOpen` and `ShellClose`. Worst case if the shell is genuinely
+    /// idle (e.g., user opened a shell and walked away), we wait 30s
+    /// instead of 6s before tearing down. Acceptable.
     fn heartbeat_timeout(&self) -> Duration {
-        if self.clipboard.transfer_in_flight() {
-            HEARTBEAT_TIMEOUT_BUSY
-        } else {
-            HEARTBEAT_TIMEOUT_IDLE
-        }
+        heartbeat_timeout_for(
+            self.clipboard.transfer_in_flight(),
+            self.shell.is_some(),
+        )
     }
 
     fn next_seq(&mut self) -> u16 {
@@ -560,6 +588,38 @@ mod tests {
         assert_eq!(session.clipboard_state().expected_len(), 1024,
             "precondition: in-flight reassembly must be active");
         (session, client)
+    }
+
+    #[test]
+    fn heartbeat_timeout_for_pure_logic() {
+        // Idle: no clipboard, no shell — strict 6s.
+        assert_eq!(
+            heartbeat_timeout_for(false, false),
+            HEARTBEAT_TIMEOUT_IDLE,
+            "with both flags false the budget must be IDLE so unplugged cables fire fast"
+        );
+
+        // Clipboard transfer alive — busy budget. (Pre-existing behaviour.)
+        assert_eq!(
+            heartbeat_timeout_for(true, false),
+            HEARTBEAT_TIMEOUT_BUSY,
+            "clipboard transfer must extend the budget"
+        );
+
+        // Shell open (no clipboard) — busy budget. (Regression for the
+        // 2026-05-06 ES `_search` channel-tear-down: 24 KB JSON response
+        // monopolised the wire long enough to miss the IDLE deadline.)
+        assert_eq!(
+            heartbeat_timeout_for(false, true),
+            HEARTBEAT_TIMEOUT_BUSY,
+            "open shell must extend the budget — wire saturation kills the IDLE deadline"
+        );
+
+        // Both — still busy.
+        assert_eq!(
+            heartbeat_timeout_for(true, true),
+            HEARTBEAT_TIMEOUT_BUSY,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

\`wd --exec\` cmd с нетривиальным response (типичный кейс: ES \`_search\` через \`--ssh\`) **роняет канал** с host disconnect'ом. На Mac side приходится reopen'ить \`WireDesk.app\` чтобы restore IPC.

## Root cause (live-test 2026-05-06)

Из host.log сегодня:
\`\`\`
05:02:43 INFO opening shell ''
05:03:26 WARN heartbeat timeout — disconnecting   ← 43s после open
\`\`\`

Adaptive heartbeat уже extend'ит budget с 6s до 30s **во время clipboard transfer'а** (\`apps/wiredesk-host/src/session.rs:134\`). Но **shell output flood** считается idle — wire saturated, Mac's writer-thread falls behind на heartbeat'ах, host через 6s disconnects.

24KB JSON через ES \`_search\` = ~2s pure wire-time + server-delay + retry timing → consistently вылетает за 6s window.

## Fix

Один \`||\` в \`heartbeat_timeout()\`:

\`\`\`rust
if self.clipboard.transfer_in_flight() || self.shell.is_some() {
    HEARTBEAT_TIMEOUT_BUSY  // 30s
} else {
    HEARTBEAT_TIMEOUT_IDLE  // 6s
}
\`\`\`

Refactor branching → pure helper \`heartbeat_timeout_for(clipboard_busy, shell_open)\` чтобы logic можно было unit-test'ить без spawn'а реального \`ShellProcess\`.

## Что НЕ изменилось

- Wire protocol unchanged.
- Mac client unchanged.
- Disconnect-on-real-cable-unplug всё ещё fires в 6s **когда shell не open** (idle path).

## Trade-off

Если shell open но реально idle (user открыл и ушёл) — disconnect-detection 30s вместо 6s. Acceptable — clipboard path уже так делает.

## Tests

- New: \`heartbeat_timeout_for_pure_logic\` — все 4 состояния (idle / clipboard-only / shell-only / both) → ожидаемые budget'ы.
- Existing \`heartbeat_timeout_resets_clipboard\` — без regression'а.
- Full \`cargo test -p wiredesk-host -- --test-threads=1\`: **98 passed** (was 97, +1).
- Clippy clean.

## Что нужно после merge

**Win11 host надо пересобрать** (\`cargo build --release -p wiredesk-host\`) и заменить \`wiredesk-host.exe\`. Старый host будет работать с новым клиентом, но bug-fix не активен пока host не обновлён.

## Followup (не в этом PR'е)

Корневая причина выше — Mac client's writer-thread heartbeat starvation при wire saturation. Этот fix лечит **симптом** (host не отключает) с правильной стороны. Долгосрочно стоит:
1. Mac heartbeat в **отдельном thread'е** (не shared с writer) → guaranteed delivery даже при congestion.
2. Auto-reconnect на Mac side когда host disconnect detected → не нужно reopen'ить app.

Tracked в \`docs/plans/concurrent-finding-lighthouse.md\` (Variant C из плана).

🤖 Generated with [Claude Code](https://claude.com/claude-code)