### PR TITLE
fix(client/ipc): drain wire after ShellClose so next request gets clean channel

### DIFF
--- a/apps/wiredesk-client/src/ipc.rs
+++ b/apps/wiredesk-client/src/ipc.rs
@@ -324,6 +324,57 @@ fn handle_connection(
     if let Err(e) = outgoing_tx.send(Packet::new(Message::ShellClose, 0)) {
         log::warn!("IPC: failed to send ShellClose: {e}");
     }
+
+    // Post-run drain: hold `single_inflight` until the wire goes idle (or
+    // host confirms ShellExit, whichever comes first). Without this the
+    // next IPC handler's ShellOpen lands on a wire still saturated with
+    // the prior cmd's in-flight ShellOutput chunks — host receives our
+    // ShellOpen but its session loop is blocked shipping the leftover
+    // output, the new ShellInput never reaches a fresh shell, and the
+    // run hangs to timeout. Live-test 2026-05-06: a single ES
+    // `_search?size=1` query produced 407 KB of output that kept
+    // streaming for ~30 s after wd-term had already returned 124 — every
+    // subsequent `wd --exec` failed timeout until we manually waited
+    // through that window.
+    //
+    // Strategy: poll for events with a 2 s idle deadline. Each event
+    // received resets the deadline; ShellExit short-circuits. If no event
+    // for 2 s straight, we treat the wire as quiet and return. Hard cap
+    // at SHELL_KILL_GRACE_MAX so a host that never emits ShellExit can't
+    // hold the next client hostage indefinitely.
+    const POST_RUN_IDLE: Duration = Duration::from_secs(2);
+    const SHELL_KILL_GRACE_MAX: Duration = Duration::from_secs(30);
+    let drain_started = std::time::Instant::now();
+    let mut drained_events: u32 = 0;
+    let mut got_exit = false;
+    loop {
+        if drain_started.elapsed() >= SHELL_KILL_GRACE_MAX {
+            log::warn!(
+                "IPC: post-cleanup drain hit max grace ({:?}); releasing single_inflight anyway",
+                SHELL_KILL_GRACE_MAX
+            );
+            break;
+        }
+        match transport.rx.recv_timeout(POST_RUN_IDLE) {
+            Ok(wiredesk_exec_core::ExecEvent::ShellExit(_)) => {
+                got_exit = true;
+                break;
+            }
+            Ok(_) => {
+                drained_events = drained_events.saturating_add(1);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => break,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    if drained_events > 0 || got_exit {
+        log::info!(
+            "IPC: post-cleanup drain: events_drained={} shell_exit={} elapsed={:?}",
+            drained_events,
+            got_exit,
+            drain_started.elapsed()
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem (live-test 2026-05-06)

После timeout'а одного \`wd --exec\` (или любого исхода когда host shell ещё активен) **следующий** wd --exec падает таймаутом потому что wire всё ещё saturated tail'ом предыдущего cmd'а.

Воспроизведено стабильно:
\`\`\`
$ wd --exec 'Invoke-RestMethod ... | ConvertTo-Json -Depth 10'
WD EXIT: 124, но 407266 bytes stdout уже captured.
Host продолжал стримить ~30s после того как wd-term вернул 124.

$ wd --exec 'echo channel-now'
timeout 124  ← следующий запрос на dirty wire
\`\`\`

Cascade: каждый failed cmd оставляет wire dirty → next тоже фейлит → user must reopen client.

## Root cause

\`apps/wiredesk-client/src/ipc.rs::handle_connection\`:
1. runner timeout → \`Err(ExecError::Timeout)\`
2. handler пишет \`Exit(124)\` клиенту
3. handler шлёт \`ShellClose\` к host'у
4. **handler сразу return'ится → \`single_inflight\` mutex освобождается**
5. host ещё несколько секунд стримит prior cmd's output
6. next handler grab'ает mutex → ShellOpen, но host's session loop блокирован shipping leftover bytes → новый ShellInput не доходит до fresh shell

## Fix

После ShellClose **держим \`single_inflight\`** до тех пор пока wire не стихнет:

\`\`\`rust
const POST_RUN_IDLE: Duration = Duration::from_secs(2);
const SHELL_KILL_GRACE_MAX: Duration = Duration::from_secs(30);

loop {
    if drain_started.elapsed() >= SHELL_KILL_GRACE_MAX { break; }
    match transport.rx.recv_timeout(POST_RUN_IDLE) {
        Ok(ShellExit(_)) => break,         // host подтвердил kill
        Ok(_) => continue,                 // discard stale ShellOutput, reset deadline
        Err(Timeout) => break,             // 2s тишины — wire idle
        Err(Disconnected) => break,
    }
}
\`\`\`

Каждый event сбрасывает 2s idle deadline. ShellExit short-circuit'ит. Hard-cap 30s чтобы crashed host не задержал нас бесконечно.

## What changes

- Mac client \`apps/wiredesk-client/src/ipc.rs\`: +51 lines, only the drain block
- **Win11 host пересобирать НЕ надо** (host code unchanged)
- After merge: rebuild \`.app\` через \`./scripts/build-mac-app.sh\`, перезапустить WireDesk.app

## Trade-off

Правильный happy-path сценарий теперь занимает доп. 2s для drain'а после exit. Это **2s ожидания на каждом \`wd --exec\`** даже если всё прошло чисто. Можно уменьшить до 500ms если 2s слишком много, но 2s даёт уверенность что post-sentinel echo + PS prompt redraw полностью drained.

Альтернатива: drain только для Err paths (Timeout, CompressionFailed). Для Ok paths runner уже видел sentinel или ShellExit, drain не нужен. Эта оптимизация — easy follow-up если 2s overhead заметен.

## Tests

- 7 IPC tests pass (no regression). \`handler_round_trip_via_unix_socket\` mock host шлёт ShellExit → drain short-circuit'ит за <1ms → runtime unchanged.
- Clippy clean.

## Followup

Не в этом PR'е:
- Mac heartbeat в отдельном thread'е (защита root-cause а не симптома)
- Mac auto-reconnect после disconnect'а
- Host-side drop in-flight ShellOutput packets из outgoing queue при ShellClose

Tracked в \`docs/plans/concurrent-finding-lighthouse.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)